### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Obol Splits</h1>
 
-This repo contains Obol Splits smart contracts. This suite of smart contracts and associated tests are intended to serve as a public good to to enable the safe and secure creation of Distributed Validators for Ethereum Consensus-based networks.
+This repo contains Obol Splits smart contracts. This suite of smart contracts and associated tests are intended to serve as a public good to enable the safe and secure creation of Distributed Validators for Ethereum Consensus-based networks.
 
 ### Disclaimer
 

--- a/script/DeployOTWRAndSplit.s.sol
+++ b/script/DeployOTWRAndSplit.s.sol
@@ -59,9 +59,9 @@ contract DeployOTWRAndSplit is Script, SplitterConfiguration {
       string memory objKey = vm.toString(i);
 
       vm.serializeAddress(objKey, "splitAddress", split);
-      string memory repsonse = vm.serializeAddress(objKey, "OTWRAddress", otwrAddress);
+      string memory response = vm.serializeAddress(objKey, "OTWRAddress", otwrAddress);
 
-      finalJSON = vm.serializeString(jsonKey, objKey, repsonse);
+      finalJSON = vm.serializeString(jsonKey, objKey, response);
     }
 
     vm.writeJson(finalJSON, "./otwr-split.json");

--- a/script/ObolLidoSetupScript.sol
+++ b/script/ObolLidoSetupScript.sol
@@ -8,7 +8,7 @@ import {SplitterConfiguration} from "./SplitterConfiguration.sol";
 
 /// @title ObolLidoScript
 /// @author Obol
-/// @notice Creates Split and ObolLidoSplit Adddresses
+/// @notice Creates Split and ObolLidoSplit Addresses
 ///
 /// @dev Takes a json file following the format defined at ./data/lido-data-sample.json
 /// and deploys split and ObolLido split contracts.
@@ -68,9 +68,9 @@ contract ObolLidoSetupScript is Script, SplitterConfiguration {
       vm.stopBroadcast();
 
       vm.serializeAddress(objKey, "splitAddress", split);
-      string memory repsonse = vm.serializeAddress(objKey, "obolLidoSplitAddress", obolLidoSplitAdress);
+      string memory response = vm.serializeAddress(objKey, "obolLidoSplitAddress", obolLidoSplitAdress);
 
-      finalJSON = vm.serializeString(jsonKey, objKey, repsonse);
+      finalJSON = vm.serializeString(jsonKey, objKey, response);
     }
 
     vm.writeJson(finalJSON, "./result.json");

--- a/src/base/BaseSplit.sol
+++ b/src/base/BaseSplit.sol
@@ -49,7 +49,7 @@ abstract contract BaseSplit is Clone {
     return _getArgAddress(WITHDRAWAL_ADDRESS_OFFSET);
   }
 
-  /// Token addresss
+  /// Token address
   /// @dev equivalent to address public immutable token
   function token() public pure virtual returns (address) {
     return _getArgAddress(TOKEN_ADDRESS_OFFSET);

--- a/src/controllers/ImmutableSplitController.sol
+++ b/src/controllers/ImmutableSplitController.sol
@@ -41,7 +41,7 @@ contract ImmutableSplitController is Clone {
   // onwer (address, 20 bytes)
   // 2; third item
   uint256 internal constant OWNER_OFFSET = 24;
-  // recipeints size (uint8, 1 byte )
+  // recipients size (uint8, 1 byte )
   // 3; third item
   uint256 internal constant RECIPIENTS_SIZE_OFFSET = 44;
   // recipients data ()
@@ -118,7 +118,7 @@ contract ImmutableSplitController is Clone {
     }
   }
 
-  /// Number of recipeints
+  /// Number of recipients
   /// @dev  equivalent to address internal immutable _recipientsSize;
   function _recipientsSize() internal pure returns (uint256) {
     return _getArgUint8(RECIPIENTS_SIZE_OFFSET);

--- a/src/eigenlayer/ObolEigenLayerPodController.sol
+++ b/src/eigenlayer/ObolEigenLayerPodController.sol
@@ -22,7 +22,7 @@ contract ObolEigenLayerPodController {
   /// @dev contract already initialized
   error AlreadyInitialized();
 
-  /// @dev Emiited on intialize
+  /// @dev Emitted on initialize
   event Initialized(address eigenPod, address owner);
 
   /// -----------------------------------------------------------------------

--- a/src/etherfi/ObolEtherfiSplitFactory.sol
+++ b/src/etherfi/ObolEtherfiSplitFactory.sol
@@ -32,7 +32,7 @@ contract ObolEtherfiSplitFactory is BaseSplitFactory {
   /// @dev Create a new collector
   /// @dev address(0) is used to represent ETH
   /// @param withdrawalAddress Address of the splitWallet to transfer weETH to
-  /// @return collector Address of the wrappper split
+  /// @return collector Address of the wrapper split
   function createCollector(address, address withdrawalAddress) external override returns (address collector) {
     if (withdrawalAddress == address(0)) revert Invalid_Address();
 

--- a/src/test/collector/ObolCollector.t.sol
+++ b/src/test/collector/ObolCollector.t.sol
@@ -69,7 +69,7 @@ contract ObolCollectorTest is Test {
   function test_token() public {
     assertEq(collectorWithFee.token(), address(mERC20), "invalid token");
 
-    assertEq(ethCollectorWithFee.token(), address(0), "ivnalid token eth");
+    assertEq(ethCollectorWithFee.token(), address(0), "invalid token eth");
   }
 
   function test_DistributeERC20WithFee() public {

--- a/src/test/controllers/IMSCFactory.t.sol
+++ b/src/test/controllers/IMSCFactory.t.sol
@@ -146,7 +146,7 @@ contract IMSCFactory is Test {
     );
   }
 
-  function test_RevertIfRecipeintSizeTooMany() public {
+  function test_RevertIfRecipientSizeTooMany() public {
     bytes32 deploymentSalt = keccak256(abi.encodePacked(uint256(1102)));
 
     uint256 size = 400;

--- a/src/test/eigenlayer/OELPCFactory.t.sol
+++ b/src/test/eigenlayer/OELPCFactory.t.sol
@@ -43,7 +43,7 @@ contract ObolEigenLayerPodControllerFactoryTest is EigenLayerTestBase {
     new ObolEigenLayerPodControllerFactory(feeRecipient, feeShare, address(0), POD_MANAGER_GOERLI, DELAY_ROUTER_GOERLI);
   }
 
-  function test_RevertIfInvalidPodManger() external {
+  function test_RevertIfInvalidPodManager() external {
     vm.expectRevert(Invalid_EigenPodManaager.selector);
     new ObolEigenLayerPodControllerFactory(
       feeRecipient, feeShare, DELEGATION_MANAGER_GOERLI, address(0), DELAY_ROUTER_GOERLI


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "repsonse" to "response".
Corrected "Adddresses" to "Addresses".
Corrected "addresss" to "address".
Corrected "recipeints" to "recipients".
Corrected "Emiited on intialize" to "Emitted on initialize".
Corrected "wrappper" to "wrapper".
Corrected "ivnalid" to "invalid" and much more.

Please review the changes and let me know if any additional changes are needed.