### PR TITLE
Fix Typographical Errors and Update HTML Structure for Legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Obol Splits</h1>
 
-This repo contains Obol Splits smart contracts. This suite of smart contracts and associated tests are intended to serve as a public good to to enable the safe and secure creation of Distributed Validators for Ethereum Consensus-based networks.
+This repo contains Obol Splits smart contracts. This suite of smart contracts and associated tests are intended to serve as a public good to enable the safe and secure creation of Distributed Validators for Ethereum Consensus-based networks.
 
 ### Disclaimer
 
@@ -34,7 +34,7 @@ cp .env.sample .env
 forge test
 ```
 
-This command starts runs all tests.
+This command runs all tests.
 
 > NOTE: To run a specific test:
 ```sh

--- a/docs/audit/SplitMainV2.md
+++ b/docs/audit/SplitMainV2.md
@@ -51,20 +51,18 @@ Source Units in Scope: **`1`** (**100%**)
 | 📝 | src/splitter/SplitMainV2.sol | 1 | **** | 720 | 645 | 245 | 346 | 209 | **<abbr title='Uses Assembly'>🖥</abbr><abbr title='Payable Functions'>💰</abbr><abbr title='Uses Hash-Functions'>🧮</abbr><abbr title='Unchecked Blocks'>Σ</abbr>** |
 | 📝 | **Totals** | **1** | **** | **720**  | **645** | **245** | **346** | **209** | **<abbr title='Uses Assembly'>🖥</abbr><abbr title='Payable Functions'>💰</abbr><abbr title='Uses Hash-Functions'>🧮</abbr><abbr title='Unchecked Blocks'>Σ</abbr>** |
 
-<sub>
-Legend: <a onclick="toggleVisibility('table-legend', this)">[➕]</a>
-<div id="table-legend" style="display:none">
-
-<ul>
-<li> <b>Lines</b>: total lines of the source unit </li>
-<li> <b>nLines</b>: normalized lines of the source unit (e.g. normalizes functions spanning multiple lines) </li>
-<li> <b>nSLOC</b>: normalized source lines of code (only source-code lines; no comments, no blank lines) </li>
-<li> <b>Comment Lines</b>: lines containing single or block comments </li>
-<li> <b>Complexity Score</b>: a custom complexity score derived from code statements that are known to introduce code complexity (branches, loops, calls, external interfaces, ...) </li>
-</ul>
-
+<div class="legend-container">
+    Legend: <a class="toggle-btn" onclick="toggleVisibility('table-legend', this)">[➕]</a>
+    <div id="table-legend" class="legend-content" style="display:none">
+        <ul>
+            <li><b>Lines</b>: total lines of the source unit</li>
+            <li><b>nLines</b>: normalized lines of the source unit (e.g. normalizes functions spanning multiple lines)</li>
+            <li><b>nSLOC</b>: normalized source lines of code (only source-code lines; no comments, no blank lines)</li>
+            <li><b>Comment Lines</b>: lines containing single or block comments</li>
+            <li><b>Complexity Score</b>: a custom complexity score derived from code statements that are known to introduce code complexity (branches, loops, calls, external interfaces, ...)</li>
+        </ul>
+    </div>
 </div>
-</sub>
 
 
 #### <span id=t-out-of-scope>Out of Scope</span>


### PR DESCRIPTION
1. **Fixed Typographical Errors:**
   - Corrected the sentence to fix redundancy:
     - **Before**: "This command starts runs all tests."
     - **After**: "This command runs all tests."
   
   - Removed the repeated word:
     - **Before**: "good to to enable"
     - **After**: "good to enable"

2. **HTML Structure Update for Legend:**
   - Updated the HTML structure for the legend to prevent text overlay issues. 
     - Added `legend-container` and improved list element organization.
     - Removed old code with incorrect structure.
     - Added a new `<div>` with the `legend-container` class.
     - Improved HTML structure for list items and added proper indentation for better readability.

### Screenshots:
- **Before**:
  ![image](https://github.com/user-attachments/assets/d961032a-c498-4154-a224-9643d5dea76f)
  
- **After**:
  ![image](https://github.com/user-attachments/assets/cd9d294c-cd00-4ba4-824b-44376f36dfbf)
