### PR TITLE
Fix Typographical Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Obol Splits</h1>
 
-This repo contains Obol Splits smart contracts. This suite of smart contracts and associated tests are intended to serve as a public good to to enable the safe and secure creation of Distributed Validators for Ethereum Consensus-based networks.
+This repo contains Obol Splits smart contracts. This suite of smart contracts and associated tests are intended to serve as a public good to enable the safe and secure creation of Distributed Validators for Ethereum Consensus-based networks.
 
 ### Disclaimer
 
@@ -34,7 +34,7 @@ cp .env.sample .env
 forge test
 ```
 
-This command starts runs all tests.
+This command runs all tests.
 
 > NOTE: To run a specific test:
 ```sh


### PR DESCRIPTION
**Fixed Typographical Errors:**
   - Corrected the sentence to fix redundancy:
     - **Before**: "This command starts runs all tests."
     - **After**: "This command runs all tests."
   
   - Removed the repeated word:
     - **Before**: "good to to enable"
     - **After**: "good to enable"