### PR TITLE
OVM: added `setAmountOfPrincipalStake()`

### DIFF
--- a/src/ovm/ObolValidatorManager.sol
+++ b/src/ovm/ObolValidatorManager.sol
@@ -114,7 +114,8 @@ contract ObolValidatorManager is OwnableRoles {
   /// Address to receive principal funds
   address public principalRecipient;
 
-  /// Amount of principal stake (wei) done via deposit() calls
+  /// Amount of principal stake (wei) done via deposit() calls, or
+  /// via setAmountOfPrincipalStake() call.
   uint256 public amountOfPrincipalStake;
 
   /// Amount of active balance set aside for pulls
@@ -196,6 +197,14 @@ contract ObolValidatorManager is OwnableRoles {
     principalRecipient = newPrincipalRecipient;
 
     emit NewPrincipalRecipient(newPrincipalRecipient, oldPrincipalRecipient);
+  }
+
+  /// @notice Overrides the amount of principal stake
+  /// @param newAmount New amount of principal stake (wei)
+  /// @dev The amount of principal stake is usually increased via deposit() calls,
+  ///      but in certain cases, it may need to be changed explicitly.
+  function setAmountOfPrincipalStake(uint256 newAmount) external onlyOwnerOrRoles(SET_PRINCIPAL_ROLE) {
+    amountOfPrincipalStake = newAmount;
   }
 
   /// Distributes target token inside the contract to recipients

--- a/src/test/ovm/ObolValidatorManager.t.sol
+++ b/src/test/ovm/ObolValidatorManager.t.sol
@@ -119,6 +119,22 @@ contract ObolValidatorManagerTest is Test {
     assertEq(ovmETH.principalRecipient(), newRecipient);
   }
 
+  function testSetAmountOfPrincipalStake() public {
+    uint256 newAmount = 1 ether;
+    ovmETH.setAmountOfPrincipalStake(newAmount);
+    assertEq(ovmETH.amountOfPrincipalStake(), newAmount);
+
+    // zero value must be allowed
+    newAmount = 0;
+    ovmETH.setAmountOfPrincipalStake(newAmount);
+    assertEq(ovmETH.amountOfPrincipalStake(), newAmount);
+
+    // no max cap
+    newAmount = type(uint256).max;
+    ovmETH.setAmountOfPrincipalStake(newAmount);
+    assertEq(ovmETH.amountOfPrincipalStake(), newAmount);
+  }
+
   function testCannot_setPrincipalRecipient() public {
     // zero address
     vm.expectRevert(ObolValidatorManager.InvalidRequest_Params.selector);


### PR DESCRIPTION
### Summary

Added the `setAmountOfPrincipalStake(uint256 newAmount)` function to allow changing the internal `amountOfPrincipalStake` counter. This is useful when consolidating validators and transferring the staked amount.

### Details

- The new function is restricted to the existing `SET_PRINCIPAL_ROLE`.
- The function does not enforce any lower or upper bounds; `newAmount` can be in the range `[0 ... type(uint256).max]`.
- No event is emitted.

### How to test it

```bash
forge test
```

ticket: none
