### PR TITLE
OVM: added `setRewardRecipient()` and scripts

### DIFF
--- a/script/ovm/GrantRolesScript.s.sol
+++ b/script/ovm/GrantRolesScript.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import "./Utils.s.sol";
+import {ObolValidatorManager} from "src/ovm/ObolValidatorManager.sol";
+
+//
+// This script calls grantRoles() for an ObolValidatorManager contract.
+// To run this script, the following environment variables must be set:
+// - PRIVATE_KEY: the private key of the account that will deploy the contract
+//
+contract GrantRolesScript is Script {
+  function run(address ovmAddress, address account, uint256 roles) external {
+    uint256 privKey = vm.envUint("PRIVATE_KEY");
+    if (privKey == 0) {
+      revert("set PRIVATE_KEY env var before using this script");
+    }
+    if (!Utils.isContract(ovmAddress)) {
+      revert("OVM address is not set or invalid");
+    }
+    if (account == address(0)) {
+      revert("Account address cannot be zero");
+    }
+    if (roles == 0) {
+      revert("Roles cannot be zero");
+    }
+
+    vm.startBroadcast(privKey);
+
+    ObolValidatorManager ovm = ObolValidatorManager(payable(ovmAddress));
+    ovm.grantRoles(account, roles);
+
+    console.log("New roles for account", ovm.rolesOf(account));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/ovm/README.md
+++ b/script/ovm/README.md
@@ -100,6 +100,32 @@ In the console, you should see the fees printed out in WEI:
   Withdrawal Fee 1 WEI
 ```
 
+## GrantRoleScript
+
+This script calls `grantRole()` for an ObolValidatorManager contract.
+
+To run this script, the following environment variables must be set:
+- `PRIVATE_KEY`: the private key of the account that will call the function
+
+Script parameters:
+- `ovmAddress`: The address of the deployed `ObolValidatorManager` contract.
+- `account`: The address to grant the role to.
+- `roles`: The roles to grant (bitwise OR).
+
+```bash
+#   SET_PRINCIPAL_ROLE = 0x04 | RECOVER_FUNDS_ROLE = 0x0C
+forge script script/ovm/GrantRoleScript.s.sol --sig "run(address,address,uint256)" \
+   --rpc-url https://ethereum-sepolia-rpc.publicnode.com --broadcast \
+   0x197d3c66a06FfD98F7316D71190EbD74262103b5 0xE84E904936C595C55b9Ad08532d9aD0A5d76df72 0x0C
+```
+
+Typical output:
+
+```
+== Logs ==
+   New roles for account 0x0C
+```
+
 ## DistributeFundsScript
 
 This script calls `distributeFunds()` for an ObolValidatorManager contract.
@@ -139,6 +165,30 @@ Typical output:
 == Logs ==
   Current principal recipient 0x46aB8712c7A5423b717F648529B1c7A17099750A
   New principal recipient set to 0xE84E904936C595C55b9Ad08532d9aD0A5d76df72
+```
+
+## SetRewardRecipientScript
+
+This script calls `setRewardRecipient()` for an ObolValidatorManager contract.
+
+To run this script, the following environment variables must be set:
+- `PRIVATE_KEY`: the private key of the account that will call the function
+
+Script parameters:
+- `ovmAddress`: The address of the deployed `ObolValidatorManager` contract.
+- `newRewardRecipient`: The address of the new reward recipient.
+
+```bash
+forge script script/ovm/SetRewardRecipientScript.s.sol --sig "run(address,address)" \
+   --rpc-url https://ethereum-sepolia-rpc.publicnode.com --broadcast 0x197d3c66a06FfD98F7316D71190EbD74262103b5 0xE84E904936C595C55b9Ad08532d9aD0A5d76df72
+```
+
+Typical output:
+
+```
+== Logs ==
+  Current reward recipient 0x46aB8712c7A5423b717F648529B1c7A17099750A
+  New reward recipient set to 0xE84E904936C595C55b9Ad08532d9aD0A5d76df72
 ```
 
 ## RequestConsolidationScript

--- a/script/ovm/SetRewardRecipientScript.s.sol
+++ b/script/ovm/SetRewardRecipientScript.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import "./Utils.s.sol";
+import {ObolValidatorManager} from "src/ovm/ObolValidatorManager.sol";
+
+//
+// This script calls setRewardRecipient() for an ObolValidatorManager contract.
+// To run this script, the following environment variables must be set:
+// - PRIVATE_KEY: the private key of the account that will deploy the contract
+//
+contract SetRewardRecipientScript is Script {
+  function run(address ovmAddress, address newRewardRecipient) external {
+    uint256 privKey = vm.envUint("PRIVATE_KEY");
+    if (privKey == 0) {
+      revert("set PRIVATE_KEY env var before using this script");
+    }
+    if (!Utils.isContract(ovmAddress)) {
+      revert("OVM address is not set or invalid");
+    }
+    if (newRewardRecipient == address(0)) {
+      revert("New reward recipient address cannot be zero");
+    }
+
+    vm.startBroadcast(privKey);
+
+    ObolValidatorManager ovm = ObolValidatorManager(payable(ovmAddress));
+
+    console.log("Current reward recipient", ovm.rewardRecipient());
+
+    ovm.setRewardRecipient(newRewardRecipient);
+
+    console.log("New reward recipient set to", ovm.rewardRecipient());
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/interfaces/IObolValidatorManager.sol
+++ b/src/interfaces/IObolValidatorManager.sol
@@ -26,6 +26,10 @@ interface IObolValidatorManager {
   /// @param newPrincipalRecipient New address to receive principal funds
   function setPrincipalRecipient(address newPrincipalRecipient) external;
 
+  /// @notice Set the reward recipient address
+  /// @param newRewardRecipient New address to receive reward funds
+  function setRewardRecipient(address newRewardRecipient) external;
+
   /// Distributes target token inside the contract to recipients
   /// @dev pushes funds to recipients
   function distributeFunds() external;

--- a/src/ovm/ObolValidatorManager.sol
+++ b/src/ovm/ObolValidatorManager.sol
@@ -52,6 +52,11 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles {
   /// @param oldPrincipalRecipient Old principal recipient address
   event NewPrincipalRecipient(address indexed newPrincipalRecipient, address indexed oldPrincipalRecipient);
 
+  /// Emitted after reward recipient is changed
+  /// @param newRewardRecipient New reward recipient address
+  /// @param oldRewardRecipient Old reward recipient address
+  event NewRewardRecipient(address indexed newRewardRecipient, address indexed oldRewardRecipient);
+
   /// Emitted after funds are distributed to recipients
   /// @param principalPayout Amount of principal paid out
   /// @param rewardPayout Amount of reward paid out
@@ -93,6 +98,7 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles {
   uint256 public constant CONSOLIDATION_ROLE = 0x02;
   uint256 public constant SET_PRINCIPAL_ROLE = 0x04;
   uint256 public constant RECOVER_FUNDS_ROLE = 0x08;
+  uint256 public constant SET_REWARD_ROLE = 0x10;
 
   uint256 internal constant PUSH = 0;
   uint256 internal constant PULL = 1;
@@ -106,7 +112,6 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles {
   address public immutable consolidationSystemContract;
   address public immutable withdrawalSystemContract;
   address public immutable depositSystemContract;
-  address public immutable rewardRecipient;
   uint64 public immutable principalThreshold;
 
   /// -----------------------------------------------------------------------
@@ -115,6 +120,9 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles {
 
   /// Address to receive principal funds
   address public principalRecipient;
+
+  /// Address to receive reward funds
+  address public rewardRecipient;
 
   /// Amount of principal stake (wei) done via deposit() calls
   uint256 public amountOfPrincipalStake;
@@ -198,6 +206,19 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles {
     principalRecipient = newPrincipalRecipient;
 
     emit NewPrincipalRecipient(newPrincipalRecipient, oldPrincipalRecipient);
+  }
+
+  /// @notice Set the reward recipient address
+  /// @param newRewardRecipient New address to receive reward funds
+  function setRewardRecipient(address newRewardRecipient) external onlyOwnerOrRoles(SET_REWARD_ROLE) {
+    if (newRewardRecipient == address(0)) {
+      revert InvalidRequest_Params();
+    }
+
+    address oldRewardRecipient = rewardRecipient;
+    rewardRecipient = newRewardRecipient;
+
+    emit NewRewardRecipient(newRewardRecipient, oldRewardRecipient);
   }
 
   /// Distributes target token inside the contract to recipients

--- a/src/ovm/ObolValidatorManagerFactory.sol
+++ b/src/ovm/ObolValidatorManagerFactory.sol
@@ -60,14 +60,6 @@ contract ObolValidatorManagerFactory {
   /// @param _ensName ENS name to register
   /// @param _ensReverseRegistrar ENS reverse registrar address
   /// @param _ensOwner ENS owner address
-  /// @dev System contracts are expected to be deployed at:
-  ///      Consolidation: 0x00431F263cE400f4455c2dCf564e53007Ca4bbBb
-  ///      https://github.com/ethereum/EIPs/blob/d96625a4dcbbe2572fa006f062bd02b4582eefd5/EIPS/eip-7251.md#constants
-  ///      Withdrawal: 0x0c15F14308530b7CDB8460094BbB9cC28b9AaaAA
-  ///      https://github.com/ethereum/EIPs/blob/d96625a4dcbbe2572fa006f062bd02b4582eefd5/EIPS/eip-7002.md#configuration
-  ///      Deposit Holesky/Devnet: 0x4242424242424242424242424242424242424242
-  ///      Deposit Sepolia: 0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D
-  ///      Deposit Mainnet: 0x00000000219ab540356cBB839Cbe05303d7705Fa
   constructor(
     address _consolidationSystemContract,
     address _withdrawalSystemContract,

--- a/src/test/ovm/ObolValidatorManager.t.sol
+++ b/src/test/ovm/ObolValidatorManager.t.sol
@@ -16,6 +16,7 @@ contract ObolValidatorManagerTest is Test {
   using SafeTransferLib for address;
 
   event NewPrincipalRecipient(address indexed newPrincipalRecipient, address indexed oldPrincipalRecipient);
+  event NewRewardRecipient(address indexed newRewardRecipient, address indexed oldRewardRecipient);
   event DistributeFunds(uint256 principalPayout, uint256 rewardPayout, uint256 pullFlowFlag);
   event RecoverNonOVMFunds(address indexed nonOVMToken, address indexed recipient, uint256 amount);
   event ConsolidationRequested(address indexed requester, bytes indexed source, bytes indexed target);
@@ -136,6 +137,36 @@ contract ObolValidatorManagerTest is Test {
     ovmETH.renounceOwnership();
     vm.expectRevert(bytes4(0x82b42900));
     ovmETH.setPrincipalRecipient(makeAddr("noaccess"));
+  }
+
+  function testSetRewardRecipient() public {
+    // initial recipient
+    assertEq(ovmETH.rewardRecipient(), rewardsRecipient, "invalid rewards recipient");
+
+    address newRecipient = makeAddr("newRecipient");
+    vm.expectEmit(true, true, true, true);
+    emit NewRewardRecipient(newRecipient, rewardsRecipient);
+    ovmETH.setRewardRecipient(newRecipient);
+    assertEq(ovmETH.rewardRecipient(), newRecipient);
+  }
+
+  function testCannot_setRewardRecipient() public {
+    // zero address
+    vm.expectRevert(ObolValidatorManager.InvalidRequest_Params.selector);
+    ovmETH.setRewardRecipient(address(0));
+
+    // unauthorized
+    address _user = vm.addr(0x2);
+    ovmETH.grantRoles(_user, ovmETH.WITHDRAWAL_ROLE()); // unrelated role
+    vm.startPrank(_user);
+    vm.expectRevert(bytes4(0x82b42900));
+    ovmETH.setRewardRecipient(makeAddr("noaccess"));
+    vm.stopPrank();
+
+    // unauthorized for owner after renounce
+    ovmETH.renounceOwnership();
+    vm.expectRevert(bytes4(0x82b42900));
+    ovmETH.setRewardRecipient(makeAddr("noaccess"));
   }
 
   function testCannot_requestConsolidation() public {


### PR DESCRIPTION
### Summary

Added `setRewardRecipient` similar to the existing `setPrincipalRecipient` function that allows changing the rewards recipient address with the corresponding dedicated role.

### Details

Additionally added the corresponding script: SetRewardRecipient and a new script to grant roles to an arbitrary account.

### How to test it

```
forge test
```

ticket: none
