### PR TITLE
fix(ovm-skill): correct deploy script threshold default

### DIFF
--- a/.claude/skills/deploy-obol-ovm/SKILL.md
+++ b/.claude/skills/deploy-obol-ovm/SKILL.md
@@ -80,7 +80,7 @@ Each write script checks that `PRIVATE_KEY` is set, prints what it's about to do
 ```bash
 .claude/skills/deploy-obol-ovm/scripts/deploy-ovm.sh <owner> <beneficiary> <reward_recipient> [threshold_gwei] [network]
 ```
-Default threshold is 16 gwei. Deploys via the network's factory contract.
+Default threshold is `16000000000` gwei (= 16 ETH). The factory rejects values above `2048000000000` (2048 ETH). Deploys via the network's factory contract.
 
 **Grant roles:**
 ```bash
@@ -188,7 +188,7 @@ When `distributeFunds()` is called:
 ### Deploy and configure a new OVM
 ```
 1. User sets PRIVATE_KEY env var
-2. Deploy:    .claude/skills/deploy-obol-ovm/scripts/deploy-ovm.sh <owner> <beneficiary> <reward> 16 hoodi
+2. Deploy:    .claude/skills/deploy-obol-ovm/scripts/deploy-ovm.sh <owner> <beneficiary> <reward> 16000000000 hoodi
 3. Query tx receipt to get the new OVM address from logs
 4. Grant roles: .claude/skills/deploy-obol-ovm/scripts/grant-roles.sh <new_ovm> <operator_addr> 33 hoodi
 5. Verify:    .claude/skills/deploy-obol-ovm/scripts/query-roles.sh <new_ovm> <operator_addr> hoodi

--- a/.claude/skills/deploy-obol-ovm/scripts/deploy-ovm.sh
+++ b/.claude/skills/deploy-obol-ovm/scripts/deploy-ovm.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Deploy a new OVM contract via the factory
-# Usage: ./deploy-ovm.sh <owner> <beneficiary> <reward_recipient> [principal_threshold_gwei] [network]
+# Usage: ./deploy-ovm.sh <owner> <beneficiary> <reward_recipient> [threshold_gwei] [network]
+#
+# threshold_gwei: principal/reward classification threshold in GWEI (not ETH, not wei).
+#                 Default 16000000000 = 16 ETH. Max accepted by factory is 2048000000000 (2048 ETH).
 #
 # Requires: PRIVATE_KEY env var set (never read or printed, only passed to cast)
 # Requires: RPC_URL env var OR uses default for the network
@@ -10,7 +13,7 @@ set -euo pipefail
 OWNER="${1:?Usage: deploy-ovm.sh <owner> <beneficiary> <reward_recipient> [threshold_gwei] [network]}"
 BENEFICIARY="${2:?Missing beneficiary address}"
 REWARD_RECIPIENT="${3:?Missing reward recipient address}"
-THRESHOLD="${4:-16}"
+THRESHOLD_GWEI="${4:-16000000000}"
 NETWORK="${5:-mainnet}"
 
 # Factory addresses per network
@@ -28,17 +31,19 @@ if [ -z "${PRIVATE_KEY:-}" ]; then
   exit 1
 fi
 
+THRESHOLD_ETH=$(awk -v g="$THRESHOLD_GWEI" 'BEGIN { printf "%.9f", g / 1000000000 }')
+
 echo "Deploying OVM on $NETWORK..."
 echo "  Factory:    $FACTORY"
 echo "  Owner:      $OWNER"
 echo "  Beneficiary: $BENEFICIARY"
 echo "  Reward:     $REWARD_RECIPIENT"
-echo "  Threshold:  $THRESHOLD gwei"
+echo "  Threshold:  $THRESHOLD_GWEI gwei (= $THRESHOLD_ETH ETH)"
 echo "  RPC:        $RPC"
 echo ""
 
 cast send "$FACTORY" \
   "createObolValidatorManager(address,address,address,uint64)" \
-  "$OWNER" "$BENEFICIARY" "$REWARD_RECIPIENT" "$THRESHOLD" \
+  "$OWNER" "$BENEFICIARY" "$REWARD_RECIPIENT" "$THRESHOLD_GWEI" \
   --rpc-url "$RPC" \
   --private-key "$PRIVATE_KEY"


### PR DESCRIPTION
## Summary
- The `deploy-ovm.sh` helper defaulted the threshold arg to `16`. The OVM factory takes `principalThreshold` in **gwei** (max `2048 * 1e9`), so the buggy default deployed OVMs with a **16-gwei** threshold instead of the intended **16 ETH**. Result: essentially all withdrawn ETH gets classified as principal and routed to the principal recipient instead of being split with the reward recipient.
- Default changed to `16000000000` (= 16 ETH in gwei). Variable renamed to `THRESHOLD_GWEI` so the unit is unambiguous at the call site. Echo now prints both gwei and the ETH equivalent so operators can spot a misplaced decimal before broadcasting.
- `SKILL.md` docs and the workflow example updated to match.

## Risk window for existing deployments
The buggy default has been on `main` since PR #192 (2026-02-19). Any OVM deployed via this skill using the bare default in that window is misconfigured, and `principalThreshold` is immutable — those contracts would need a redeploy + migration. A separate check against the three factories (`0x2c26...` mainnet, `0x5754...` hoodi, `0xF32F...` sepolia) is being done to enumerate any affected deployments via `CreateObolValidatorManager` event logs.

## Test plan
- [x] Dry-run `deploy-ovm.sh` with no 4th arg and confirm echo shows `16000000000 gwei (= 16.000000000 ETH)`
- [x] Dry-run with explicit `1000000000` and confirm echo shows `1.000000000 ETH`
- [x] Confirm `SKILL.md` example uses `16000000000` and the docs sentence matches