### PR TITLE
Revert "OVM deposit() refactor"

### DIFF
--- a/src/interfaces/IObolValidatorManager.sol
+++ b/src/interfaces/IObolValidatorManager.sol
@@ -97,9 +97,6 @@ interface IObolValidatorManager {
   /// @notice Invalid distribution
   error InvalidDistribution_TooLarge();
 
-  /// @notice Deposit withdrawal credentials do not commit to this contract's address
-  error InvalidDeposit_WithdrawalCredentials();
-
   /// -----------------------------------------------------------------------
   /// ObolValidatorManager functions
   /// -----------------------------------------------------------------------
@@ -107,8 +104,6 @@ interface IObolValidatorManager {
   /// @notice Submit a Phase 0 DepositData object.
   /// @param pubkey A BLS12-381 public key.
   /// @param withdrawal_credentials Commitment to a public key for withdrawals.
-  /// Must commit to this contract's address: a 0x01 or 0x02 prefix, 11 zero bytes,
-  /// and this contract's address. Reverts with InvalidDeposit_WithdrawalCredentials otherwise.
   /// @param signature A BLS12-381 signature.
   /// @param deposit_data_root The SHA-256 hash of the SSZ-encoded DepositData object.
   /// Used as a protection against malformed input.

--- a/src/ovm/ObolValidatorManager.sol
+++ b/src/ovm/ObolValidatorManager.sol
@@ -39,10 +39,6 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles, Reentrancy
 
   uint256 internal constant PUBLIC_KEY_LENGTH = 48;
 
-  uint256 internal constant WITHDRAWAL_CREDENTIALS_LENGTH = 32;
-  bytes32 internal constant ETH1_WITHDRAWAL_PREFIX = bytes32(uint256(0x01) << 248);
-  bytes32 internal constant COMPOUNDING_WITHDRAWAL_PREFIX = bytes32(uint256(0x02) << 248);
-
   /// -----------------------------------------------------------------------
   /// storage - immutable
   /// -----------------------------------------------------------------------
@@ -121,8 +117,6 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles, Reentrancy
     bytes calldata signature,
     bytes32 deposit_data_root
   ) external payable onlyOwnerOrRoles(DEPOSIT_ROLE) {
-    _validateWithdrawalCredentials(withdrawal_credentials);
-
     uint256 oldAmountOfPrincipalStake = amountOfPrincipalStake;
     amountOfPrincipalStake += msg.value;
     IDepositContract(depositSystemContract).deposit{value: msg.value}(
@@ -433,21 +427,6 @@ contract ObolValidatorManager is IObolValidatorManager, OwnableRoles, Reentrancy
   /// @param pubkey The public key to validate
   function _validatePubkeyLength(bytes memory pubkey) internal pure {
     if (pubkey.length != PUBLIC_KEY_LENGTH) revert InvalidRequest_Params();
-  }
-
-  /// Internal function to validate that withdrawal credentials commit to this contract's address,
-  /// so that validator withdrawals cannot bypass the principal/reward accounting.
-  /// Accepted formats: 0x01 (ETH1) or 0x02 (compounding) prefix, 11 zero bytes, this contract's address.
-  /// @param withdrawal_credentials The withdrawal credentials to validate
-  function _validateWithdrawalCredentials(bytes calldata withdrawal_credentials) internal view {
-    if (withdrawal_credentials.length != WITHDRAWAL_CREDENTIALS_LENGTH) revert InvalidDeposit_WithdrawalCredentials();
-
-    bytes32 credentials = bytes32(withdrawal_credentials);
-    bytes32 addressPart = bytes32(uint256(uint160(address(this))));
-    if (
-      credentials != (ETH1_WITHDRAWAL_PREFIX | addressPart)
-        && credentials != (COMPOUNDING_WITHDRAWAL_PREFIX | addressPart)
-    ) revert InvalidDeposit_WithdrawalCredentials();
   }
 
   /// Internal function to refund the excess fee for pectra related operations.

--- a/src/test/ovm/ObolValidatorManager.t.sol
+++ b/src/test/ovm/ObolValidatorManager.t.sol
@@ -93,18 +93,8 @@ contract ObolValidatorManagerTest is Test {
       principalThreshold
     );
 
-    ovmETH.deposit{value: INITIAL_DEPOSIT_AMOUNT}(
-      new bytes(0),
-      _withdrawalCredentials(ovmETH, 0x02),
-      new bytes(0),
-      bytes32(0)
-    );
-    ovmETH_OR.deposit{value: INITIAL_DEPOSIT_AMOUNT}(
-      new bytes(0),
-      _withdrawalCredentials(ovmETH_OR, 0x02),
-      new bytes(0),
-      bytes32(0)
-    );
+    ovmETH.deposit{value: INITIAL_DEPOSIT_AMOUNT}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
+    ovmETH_OR.deposit{value: INITIAL_DEPOSIT_AMOUNT}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
   }
 
   function testDefaultParameters() public view {
@@ -123,15 +113,8 @@ contract ObolValidatorManagerTest is Test {
     uint256 depositAmount = 1 ether;
     vm.expectEmit(true, true, true, true);
     emit PrincipalStakeAmountUpdated(amountOfPrincipalStake + depositAmount, amountOfPrincipalStake);
-    ovmETH.deposit{value: depositAmount}(new bytes(0), _withdrawalCredentials(ovmETH, 0x02), new bytes(0), bytes32(0));
+    ovmETH.deposit{value: depositAmount}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
     assertEq(address(depositMock).balance, depositMockBalance + depositAmount);
-    assertEq(ovmETH.amountOfPrincipalStake(), amountOfPrincipalStake + depositAmount);
-  }
-
-  function testDepositWithEth1WithdrawalCredentials() public {
-    uint256 amountOfPrincipalStake = ovmETH.amountOfPrincipalStake();
-    uint256 depositAmount = 1 ether;
-    ovmETH.deposit{value: depositAmount}(new bytes(0), _withdrawalCredentials(ovmETH, 0x01), new bytes(0), bytes32(0));
     assertEq(ovmETH.amountOfPrincipalStake(), amountOfPrincipalStake + depositAmount);
   }
 
@@ -142,51 +125,13 @@ contract ObolValidatorManagerTest is Test {
     ovmETH.grantRoles(_user, ovmETH.WITHDRAWAL_ROLE()); // unrelated role
     vm.startPrank(_user);
     vm.expectRevert(bytes4(0x82b42900));
-    ovmETH.deposit{value: 1 ether}(new bytes(0), _withdrawalCredentials(ovmETH, 0x02), new bytes(0), bytes32(0));
+    ovmETH.deposit{value: 1 ether}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
     vm.stopPrank();
 
     // unauthorized for owner after renounce
     ovmETH.renounceOwnership();
     vm.expectRevert(bytes4(0x82b42900));
-    ovmETH.deposit{value: 1 ether}(new bytes(0), _withdrawalCredentials(ovmETH, 0x02), new bytes(0), bytes32(0));
-  }
-
-  function testCannotDepositWithInvalidWithdrawalCredentials() public {
-    // empty credentials
-    vm.expectRevert(IObolValidatorManager.InvalidDeposit_WithdrawalCredentials.selector);
     ovmETH.deposit{value: 1 ether}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
-
-    // wrong length: 31 bytes
-    vm.expectRevert(IObolValidatorManager.InvalidDeposit_WithdrawalCredentials.selector);
-    ovmETH.deposit{value: 1 ether}(new bytes(0), new bytes(31), new bytes(0), bytes32(0));
-
-    // wrong length: 33 bytes (valid credentials + 1 extra byte)
-    bytes memory tooLong = abi.encodePacked(_withdrawalCredentials(ovmETH, 0x02), bytes1(0));
-    vm.expectRevert(IObolValidatorManager.InvalidDeposit_WithdrawalCredentials.selector);
-    ovmETH.deposit{value: 1 ether}(new bytes(0), tooLong, new bytes(0), bytes32(0));
-
-    // wrong prefix: 0x00 (BLS credentials)
-    vm.expectRevert(IObolValidatorManager.InvalidDeposit_WithdrawalCredentials.selector);
-    ovmETH.deposit{value: 1 ether}(new bytes(0), _withdrawalCredentials(ovmETH, 0x00), new bytes(0), bytes32(0));
-
-    // wrong prefix: 0x03
-    vm.expectRevert(IObolValidatorManager.InvalidDeposit_WithdrawalCredentials.selector);
-    ovmETH.deposit{value: 1 ether}(new bytes(0), _withdrawalCredentials(ovmETH, 0x03), new bytes(0), bytes32(0));
-
-    // wrong address: credentials commit to an address other than the OVM
-    bytes memory wrongAddress = abi.encodePacked(bytes1(0x02), bytes11(0), makeAddr("attacker"));
-    vm.expectRevert(IObolValidatorManager.InvalidDeposit_WithdrawalCredentials.selector);
-    ovmETH.deposit{value: 1 ether}(new bytes(0), wrongAddress, new bytes(0), bytes32(0));
-
-    // non-zero padding bytes
-    bytes memory dirtyPadding = abi.encodePacked(bytes1(0x02), bytes11(uint88(1)), address(ovmETH));
-    vm.expectRevert(IObolValidatorManager.InvalidDeposit_WithdrawalCredentials.selector);
-    ovmETH.deposit{value: 1 ether}(new bytes(0), dirtyPadding, new bytes(0), bytes32(0));
-  }
-
-  /// Builds withdrawal credentials committing to the given OVM: prefix + 11 zero bytes + OVM address
-  function _withdrawalCredentials(ObolValidatorManager ovm, bytes1 prefix) internal pure returns (bytes memory) {
-    return abi.encodePacked(prefix, bytes11(0), address(ovm));
   }
 
   function testSetBeneficiaryRecipient() public {
@@ -780,7 +725,7 @@ contract ObolValidatorManagerTest is Test {
   function testCan_distributeToBothRecipients() public {
     // First deposit of 32eth is done in setUp()
     uint256 secondDeposit = 64 ether;
-    ovmETH.deposit{value: secondDeposit}(new bytes(0), _withdrawalCredentials(ovmETH, 0x02), new bytes(0), bytes32(0));
+    ovmETH.deposit{value: secondDeposit}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
     uint256 rewardPayout = 4 ether;
     address(ovmETH).safeTransferETH(INITIAL_DEPOSIT_AMOUNT + secondDeposit + rewardPayout);
 
@@ -838,7 +783,7 @@ contract ObolValidatorManagerTest is Test {
     ObolValidatorManagerReentrancy re = new ObolValidatorManagerReentrancy();
 
     ovmETH = ovmFactory.createObolValidatorManager(address(this), address(re), rewardsRecipient, 1e9);
-    ovmETH.deposit{value: 1 ether}(new bytes(0), _withdrawalCredentials(ovmETH, 0x02), new bytes(0), bytes32(0));
+    ovmETH.deposit{value: 1 ether}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
     address(ovmETH).safeTransferETH(33 ether);
 
     vm.expectRevert(SafeTransferLib.ETHTransferFailed.selector);
@@ -999,7 +944,7 @@ contract ObolValidatorManagerTest is Test {
     );
 
     uint256 _totalETHAmount = uint256(_numDeposits) * uint256(_ethAmount);
-    ovm.deposit{value: _totalETHAmount}(new bytes(0), _withdrawalCredentials(ovm, 0x02), new bytes(0), bytes32(0));
+    ovm.deposit{value: _totalETHAmount}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
 
     /// test eth
     for (uint256 i = 0; i < _numDeposits; i++) {
@@ -1048,7 +993,7 @@ contract ObolValidatorManagerTest is Test {
     );
 
     uint256 _totalETHAmount = uint256(_numDeposits) * uint256(_ethAmount);
-    ovm.deposit{value: _totalETHAmount}(new bytes(0), _withdrawalCredentials(ovm, 0x02), new bytes(0), bytes32(0));
+    ovm.deposit{value: _totalETHAmount}(new bytes(0), new bytes(0), new bytes(0), bytes32(0));
 
     for (uint256 i = 0; i < _numDeposits; i++) {
       address(ovm).safeTransferETH(_ethAmount);


### PR DESCRIPTION
Reverts ObolNetwork/obol-splits#199

Kept forge-std pinned to the right version to make all tests passing.